### PR TITLE
Enable Robolectric to use the same resources as Android

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,6 @@ org.gradle.caching=true
 # AndroidX
 android.useAndroidX=true
 android.enableJetifier=true
+
+# Enable Robolectric to use the same resources as Android
+android.enableUnitTestBinaryResources=true


### PR DESCRIPTION
This should speed up tests startup time and reduce memory consumption as well as bring more fidelity to the tests.

_Note:_ For some reason setting `enableUnitTestBinaryResources = true` in build.gradle file, as advised in some resources, doesn't work, so it is set in gradle.properties.